### PR TITLE
_underlyingPanzoomInterop null-check on dispose

### DIFF
--- a/src/BlazorPanzoom/Components/Panzoom.cs
+++ b/src/BlazorPanzoom/Components/Panzoom.cs
@@ -28,7 +28,10 @@ namespace BlazorPanzoom
         public async ValueTask DisposeAsync()
         {
             GC.SuppressFinalize(this);
-            await _underlyingPanzoomInterop.DisposeAsync();
+            if (_underlyingPanzoomInterop != null)
+            {
+                await _underlyingPanzoomInterop.DisposeAsync();
+            }
         }
 
         public async ValueTask PanAsync(double x, double y, IPanOnlyOptions? overridenOptions = default)


### PR DESCRIPTION
I used the component in combination with tabs and experienced that DisposeAsync could be called before OnAfterRenderAsync when rapidly switching between tabs, which led to a crash of the site.