### PR TITLE
Fix PanzoomOptions visibillity

### DIFF
--- a/src/BlazorPanzoom/Components/Panzoom.cs
+++ b/src/BlazorPanzoom/Components/Panzoom.cs
@@ -21,7 +21,7 @@ namespace BlazorPanzoom
 
         [Parameter] public WheelMode WheelMode { get; set; } = WheelMode.None;
         [Parameter] public EventCallback<CustomWheelEventArgs> OnWheel { get; set; }
-        [Parameter] public PanzoomOptions PanzoomOptions { private get; set; } = PanzoomOptions.DefaultOptions;
+        [Parameter] public PanzoomOptions PanzoomOptions { get; set; } = PanzoomOptions.DefaultOptions;
         [Parameter] public RenderFragment<Panzoom>? ChildContent { get; set; }
         [Parameter] public EventCallback<SetTransformEventArgs> SetTransform { get; set; }
 


### PR DESCRIPTION
Get rid of the following error:
`The property or indexer 'Panzoom.PanzoomOptions' cannot be used in this context because it lacks the get accessor`